### PR TITLE
fix: fix load table entry bug

### DIFF
--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -827,7 +827,7 @@ impl ObTableLocation {
         let mut conn = pool.try_get_conn(u::duration_to_millis(&connect_timeout) as u32)?;
         let sql = match key.table_name.as_ref() {
         ALL_DUMMY_TABLE => format!("SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port,
-                                    A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port,
+                                    A.table_id as table_id, A.role as role, A.part_num as part_num, B.svr_port as svr_port,
                                     B.status as status, B.stop_time as stop_time FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server
                                     B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port WHERE tenant_name = '{}' and database_name='{}'
                                     and table_name ='{}'",


### PR DESCRIPTION
Fix following error.
```
2022-11-01 10:31:59.444 INFO [/home/xikai.wxk/.cargo/git/checkouts/obkv-table-client-rs-4fa64c39e1be7389/318907f/src/location/mod.rs:561] ObTableLocation::get_or_create_mysql_pool create mysql pool server xx port 2881 db_name oceanbase.
2022-11-01 10:31:59.454 ERRO [/home/xikai.wxk/.cargo/git/checkouts/obkv-table-client-rs-4fa64c39e1be7389/318907f/src/location/mod.rs:858] ObTableLocation::get_table_entry_from_remote: fail to do mysql row conversion, err:Couldn't convert the row `Row { partition_id: Bytes("0"), svr_ip: Bytes("1xx."), sql_port: Bytes("2881"), table_id: Bytes("xx.."), role: Bytes("1"), replica_num: Bytes("3"), part_num: Bytes("1"), svr_port: Bytes("2882"), status: Bytes("active"), stop_time: Bytes("0") }` to a desired type
2022-11-01 10:31:59.590 ERRO [common_util/src/panic.rs:42] thread 'main' panicked 'Failed to setup analytic engine: OpenObkv { source: InitClient { full_user_name: "xx", source: Common(ConvertFailed, "mysql row conversion err:Couldn't convert the row `Row { partition_id: Bytes(\"0\"), svr_ip: Bytes(\"xx..\"), sql_port: Bytes(\"2881\"), table_id: Bytes(\"xx..\"), role: Bytes(\"1\"), replica_num: Bytes(\"3\"), part_num: Bytes(\"1\"), svr_port: Bytes(\"2882\"), status: Bytes(\"active\"), stop_time: Bytes(\"0\") }` to a desired type"), backtrace: Backtrace(   0: <snafu::backtrace_shim::Backtrace as snafu::GenerateBacktrace>::generate
             at /home/xikai.wxk/code/ceresdb/components/table_kv/src/obkv.rs:23:17
      <table_kv::obkv::InitClient<__T0> as snafu::IntoError<table_kv::obkv::Error>>::into_error
             at /home/xikai.wxk/code/ceresdb/components/table_kv/src/obkv.rs:23:17
      <core::result::Result<T,E> as snafu::ResultExt<T,E>>::context::{{closure}}
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.6.10/src/lib.rs:318:30
      core::result::Result<T,E>::map_err
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/result.rs:855:27
      <core::result::Result<T,E> as snafu::ResultExt<T,E>>::context
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.6.10/src/lib.rs:318:9
      table_kv::obkv::ObkvImpl::new
             at /home/xikai.wxk/code/ceresdb/components/table_kv/src/obkv.rs:315:9
   1: <analytic_engine::setup::ReplicatedEngineBuilder as analytic_engine::setup::EngineBuilder>::open_wal_and_manifest::{{closure}}::{{closure}}
             at /home/xikai.wxk/code/ceresdb/analytic_engine/src/setup.rs:148:37
      <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/blocking/task.rs:42:21
   2: tokio::runtime::task::core::CoreStage<T>::poll::{{closure}}
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/core.rs:165:17
      tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/loom/std/unsafe_cell.rs:14:9
      tokio::runtime::task::core::CoreStage<T>::poll
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/core.rs:155:13
      tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/harness.rs:480:19
      <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/panic/unwind_safe.rs:271:9
   3: std::panicking::try::do_call
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/panicking.rs:492:40
      std::panicking::try
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/panicking.rs:456:19
      std::panic::catch_unwind
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/panic.rs:137:14
      tokio::runtime::task::harness::poll_future
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/harness.rs:468:18
      tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/harness.rs:104:27
      tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/xikai.wxk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/task/harness.rs:57:15
   4: tokio::runtime::task::raw::RawTask::poll
```