### PR TITLE
replace rust-crypto with sha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,12 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,12 +805,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -1388,7 +1376,7 @@ dependencies = [
  "mysql-common-derive",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "saturating",
@@ -1494,9 +1482,8 @@ dependencies = [
  "prometheus-client",
  "quick-error",
  "r2d2",
- "rand 0.8.5",
+ "rand",
  "reqwest",
- "rust-crypto",
  "scheduled-thread-pool",
  "scoped_threadpool",
  "serde",
@@ -1505,6 +1492,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "serial_test_derive",
+ "sha1",
  "socket2 0.5.3",
  "spin 0.9.8",
  "tempfile",
@@ -1524,7 +1512,7 @@ dependencies = [
  "anyhow",
  "log",
  "obkv-table-client-rs",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sql-builder",
  "sqlite",
@@ -1736,36 +1724,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1775,23 +1740,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1800,15 +1750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1935,19 +1876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-dependencies = [
- "gcc",
- "libc",
- "rand 0.3.23",
- "rustc-serialize",
- "time 0.1.45",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +1887,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -1970,12 +1898,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustix"
@@ -2673,7 +2595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -2740,7 +2662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
 dependencies = [
  "getrandom",
- "rand 0.8.5",
+ "rand",
  "uuid-macro-internal",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ quick-error = "1.2"
 r2d2 = "0.8.3"
 rand = "0.8"
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "blocking"] }
-rust-crypto = "0.2"
+sha1 = "0.10.5"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,12 @@ quick-error = "1.2"
 r2d2 = "0.8.3"
 rand = "0.8"
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls", "blocking"] }
-sha1 = "0.10.5"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"
+sha1 = "0.10.5"
 socket2 = "0.5"
 spin = "0.9"
 tokio = { workspace = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,6 @@ extern crate reqwest;
 extern crate serde_json;
 #[macro_use]
 extern crate log;
-extern crate crypto;
 extern crate futures_cpupool;
 #[macro_use]
 extern crate lazy_static;

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -17,8 +17,9 @@
 
 /// Password security module
 use std::cell::RefCell;
-use sha1::{Sha1, Digest};
 use std::num::Wrapping;
+
+use sha1::{Digest, Sha1};
 
 use super::current_time_millis;
 

--- a/src/util/security.rs
+++ b/src/util/security.rs
@@ -78,10 +78,10 @@ pub fn scramble_password(password: &str, seed: &str) -> Vec<u8> {
     let mut hasher = Sha1::new();
     hasher.update(password);
     let pass1 = hasher.finalize_reset();
-    hasher.update(&pass1);
+    hasher.update(pass1);
     let pass2 = hasher.finalize_reset();
     hasher.update(seed);
-    hasher.update(&pass2);
+    hasher.update(pass2);
     let mut pass3 = hasher.finalize_reset();
 
     for i in 0..pass3.len() {


### PR DESCRIPTION
* replace rust-crypto with sha1 since rust-crypto may be deprecated in the future

<!--
Thank you for contributing to **OceanBase**! 

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description

This project use the package `rust-crypto`, which will be rejected by a future version of Rust. Therefore i replace `rust-crpto` with [`sha1`](https://docs.rs/sha1/latest/sha1/)

![image](https://github.com/oceanbase/obkv-table-client-rs/assets/53596783/4772044e-22ad-48bf-a27c-e386e4f146a9)

<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->

### Solution Description

Just replace `rust-crypto` with `sha1` and port `crate::util::security::scramble_password`. 
<!-- Please clearly and consice descipt the solution. -->

### Passed Regressions

Yest.
<!-- Unittest, mysql test or test it manually? -->

### Upgrade Compatibility

<!-- Please make sure this is compatible with old version or you should give us upgrading solution. -->

### Other Information

<!-- Any information helping to review this pull request. -->

### Release Note
<!--
A concise release note can help users to understand how your pull request makes difference.
-->
