### PR TITLE
fix: invalidate_table when get_or_refresh_table_entry failed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
   LOCK_FILE: Cargo.lock
-  RUST_VERSION: nightly-2023-02-02
+  RUST_VERSION: nightly-2023-08-28
 
 jobs:
   style-check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        rust: [ nightly-2023-02-02 ]
+        rust: [ nightly-2023-08-28 ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2023-02-02
+[toolchain]
+channel = "nightly-2023-08-28"
+components = [ "rustfmt", "clippy" ]

--- a/src/client/query.rs
+++ b/src/client/query.rs
@@ -365,7 +365,7 @@ impl QueryStreamResult {
         if has_next {
             self.pop_next_row_from_cache()
         } else {
-            //4. Reach the end.
+            // 4. Reach the end.
             self.eof = true;
             self.close_eagerly("eof").await;
             Ok(None)

--- a/src/client/table_client.rs
+++ b/src/client/table_client.rs
@@ -1123,6 +1123,7 @@ impl ObTableClientInner {
             if let Err(e) = self.get_or_refresh_table_entry(&table_name, true) {
                 error!("ObTableClientInner::refresh_all_table_entries fail to refresh table entry for table: {}, err: {}.",
                                  table_name, e);
+                self.invalidate_table(&table_name);
             }
         }
         OBKV_CLIENT_METRICS.observe_sys_operation_rt("refresh_all_tables", start.elapsed());
@@ -1130,13 +1131,13 @@ impl ObTableClientInner {
 
     fn init(&self) -> Result<()> {
         if self.is_initialized() {
-            warn!("ObTableClientInner::init already initialzied.");
+            warn!("ObTableClientInner::init already initialized.");
             return Ok(());
         }
 
         let _lock = self.status_mutex.lock();
         if self.is_initialized() {
-            warn!("ObTableClientInner::init already initialzied.");
+            warn!("ObTableClientInner::init already initialized.");
             return Ok(());
         }
         self.initialized.store(true, Ordering::Release);

--- a/src/client/table_client.rs
+++ b/src/client/table_client.rs
@@ -1121,7 +1121,7 @@ impl ObTableClientInner {
 
         for table_name in tables {
             if let Err(e) = self.get_or_refresh_table_entry(&table_name, true) {
-                error!("ObTableClientInner::refresh_all_table_entries fail to refresh table entry for table: {}, err: {}.",
+                warn!("ObTableClientInner::refresh_all_table_entries fail to refresh table entry for table: {}, err: {}.",
                                  table_name, e);
                 self.invalidate_table(&table_name);
             }

--- a/src/client/table_client.rs
+++ b/src/client/table_client.rs
@@ -423,10 +423,10 @@ impl ObTableClientInner {
         end_inclusive: bool,
         refresh: bool,
     ) -> Result<Vec<(i64, Arc<ObTable>)>> {
-        //1. get table entry info
+        // 1. get table entry info
         let table_entry = self.get_or_refresh_table_entry(table_name, refresh)?;
 
-        //2. get replica locaton
+        // 2. get replica location
         let part_id_with_replicas: Vec<(i64, ReplicaLocation)> =
             self.get_partition_leaders(&table_entry, start, start_inclusive, end, end_inclusive)?;
 

--- a/src/location/mod.rs
+++ b/src/location/mod.rs
@@ -1045,13 +1045,12 @@ impl ObTableLocation {
                 role: role.clone(),
             };
 
-            let mut location =
-                partition_location
-                    .entry(partition_id)
-                    .or_insert(ObPartitionLocation {
-                        leader: None,
-                        followers: vec![],
-                    });
+            let location = partition_location
+                .entry(partition_id)
+                .or_insert(ObPartitionLocation {
+                    leader: None,
+                    followers: vec![],
+                });
 
             match role {
                 ObServerRole::Leader => location.leader = Some(replica),

--- a/ycsb-rs/src/obkv_client.rs
+++ b/ycsb-rs/src/obkv_client.rs
@@ -161,7 +161,7 @@ impl OBKVClient {
         table: &str,
         key: &str,
         columns: &Vec<String>,
-        result: &mut HashMap<String, String>,
+        result: HashMap<String, String>,
     ) -> Result<()> {
         let result = self
             .client
@@ -207,7 +207,7 @@ impl OBKVClient {
         startkey: &str,
         endkey: &str,
         columns: &Vec<String>,
-        result: &mut HashMap<String, String>,
+        result: HashMap<String, String>,
     ) -> Result<()> {
         let query = self
             .client
@@ -231,7 +231,7 @@ impl OBKVClient {
         table: &str,
         keys: &Vec<String>,
         columns: &Vec<String>,
-        result: &mut HashMap<String, String>,
+        result: HashMap<String, String>,
     ) -> Result<()> {
         let mut batch_op = self.client.batch_operation(keys.len());
         for key in keys {

--- a/ycsb-rs/src/workload/core_workload.rs
+++ b/ycsb-rs/src/workload/core_workload.rs
@@ -142,8 +142,8 @@ impl CoreWorkload {
     async fn ob_transaction_read(&self, db: Arc<OBKVClient>) {
         let keynum = self.next_key_num();
         let dbkey = format!("{}", fnvhash64(keynum));
-        let mut result = HashMap::new();
-        db.read(&self.table, &dbkey, &self.field_names, &mut result)
+        let result = HashMap::new();
+        db.read(&self.table, &dbkey, &self.field_names, result)
             .await
             .unwrap();
     }
@@ -186,16 +186,10 @@ impl CoreWorkload {
         let start = self.next_key_num();
         let dbstart = format!("{}", fnvhash64(start));
         let dbend = format!("{}", fnvhash64(start));
-        let mut result = HashMap::new();
-        db.scan(
-            &self.table,
-            &dbstart,
-            &dbend,
-            &self.field_names,
-            &mut result,
-        )
-        .await
-        .unwrap();
+        let result = HashMap::new();
+        db.scan(&self.table, &dbstart, &dbend, &self.field_names, result)
+            .await
+            .unwrap();
     }
 
     async fn ob_transaction_batchread(&self, db: Arc<OBKVClient>) {
@@ -207,8 +201,8 @@ impl CoreWorkload {
             keys.push(dbkey);
         }
 
-        let mut result = HashMap::new();
-        db.batch_read(&self.table, &keys, &self.field_names, &mut result)
+        let result = HashMap::new();
+        db.batch_read(&self.table, &keys, &self.field_names, result)
             .await
             .unwrap();
     }


### PR DESCRIPTION
## Summary
`refresh_all_table_entries` will always run in the background. When the table table does not exist, an error will always be reported, to avoid this invalidate_table is required.



## Solution Description
When table `get_or_refresh_table_entry` failed, invalidate this table.
