### PR TITLE
fix: invalidate_table when get_or_refresh_table_entry failed

### DIFF
--- a/src/client/table_client.rs
+++ b/src/client/table_client.rs
@@ -1151,8 +1151,9 @@ impl ObTableClientInner {
 
         for table_name in tables {
             if let Err(e) = self.get_or_refresh_table_entry(&table_name, true) {
-                error!("ObTableClientInner::refresh_all_table_entries fail to refresh table entry for table: {}, err: {}.",
+                warn!("ObTableClientInner::refresh_all_table_entries fail to refresh table entry for table: {}, err: {}.",
                                  table_name, e);
+                self.invalidate_table(&table_name);
             }
         }
         OBKV_CLIENT_METRICS.observe_sys_operation_rt("refresh_all_tables", start.elapsed());


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
refresh_all_table_entries will always run in the background. When the table table does not exist, an error will always be reported, to avoid this invalidate_table is required.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
When table get_or_refresh_table_entry failed, invalidate this table.